### PR TITLE
Mailing list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ The repository has no (pre)releases yet, work in progress is within the main bra
 * Mailing List
     <!-- Note: the $mailinglistname$ is either already existing (for API Repositories within a Sub Projects) or will be created by the CAMARA Admin Team. -->
     * Subscribe / Unsubscribe to the mailing list https://lists.camaraproject.org/g/sp-efn.
-    * A message to the community of this Sub Project can be sent using <$mailinglistname§@lists.camaraproject.org>.
+    * A message to the community of this Sub Project can be sent using sp-efn@lists.camaraproject.org.


### PR DESCRIPTION
Mailing list address missing in the README file

#### What type of PR is this?
* documentation

#### What this PR does / why we need it:
This PR adds the Mailing list address in the README file

#### Which issue(s) this PR fixes:
https://github.com/camaraproject/EnergyFootprintNotification/issues/7#issuecomment-2606854110
